### PR TITLE
Fix /#definitions/Team -> #/definitions/Team

### DIFF
--- a/schemas/runscope-swagger.json
+++ b/schemas/runscope-swagger.json
@@ -1063,7 +1063,7 @@
                 "teams": {
                     "type": "array",
                     "items": {
-                        "$ref": "/#definitions/Team"
+                        "$ref": "#/definitions/Team"
                     }
                 }
             }


### PR DESCRIPTION
Still seems to be a missing definition for `$ref`: `#/definitions/Test`